### PR TITLE
onLongClick, deleting/get functions on Api class 

### DIFF
--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdFrag.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdFrag.kt
@@ -7,6 +7,10 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 class AdFrag : AppCompatActivity(), MyAdRecyclerViewAdapter.onAdClickListener {
 
@@ -14,6 +18,8 @@ class AdFrag : AppCompatActivity(), MyAdRecyclerViewAdapter.onAdClickListener {
     private lateinit var addAdsButton: Button
     private lateinit var editCampaignButton: Button
     private lateinit var adRecyclerView: RecyclerView
+    private val campaignJob = Job()
+    private val coroutineScope = CoroutineScope(campaignJob + Dispatchers.Main)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -25,6 +31,9 @@ class AdFrag : AppCompatActivity(), MyAdRecyclerViewAdapter.onAdClickListener {
 
         adRecyclerView.layoutManager = LinearLayoutManager(this)
         adRecyclerView.adapter = adAdapter
+
+        refreshAds()
+
         // GET FOR AD LIST
         addAdsButton.setOnClickListener {
             val intent: Intent = Intent(this, AddAdActivity::class.java)
@@ -43,10 +52,47 @@ class AdFrag : AppCompatActivity(), MyAdRecyclerViewAdapter.onAdClickListener {
 
     override fun onResume() {
         super.onResume()
-        adAdapter.update(Ads.adList)
+//        adAdapter.update(Ads.adList)
+        refreshAds()
     }
 
     override fun onItemClick(value: Ads.AdItem, position: Int) {
         Toast.makeText(this, value.mainText, Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onLongItemClick(value: Ads.AdItem, position: Int) {
+        val campaignid: Int = getIntent().extras?.getInt("campaignid") ?: -1
+        deleteAdById(campaignid)
+    }
+
+    //Refreshing list after leaving home page and coming back to it
+    private fun refreshAds() {
+        coroutineScope.launch {
+            val campaignid: Int = getIntent().extras?.getInt("campaignid") ?: -1
+            var getAdsDeferred = AdServerApi.retrofitService.getCampAds(campaignid)
+            try {
+                var listResult = getAdsDeferred.await()
+                Ads.setItems(listResult.toMutableList())
+                Toast.makeText(applicationContext, "Success: ${listResult.size}", Toast.LENGTH_SHORT).show()
+                adAdapter.update(Ads.adList)
+            } catch (t: Throwable) {
+                Toast.makeText(applicationContext, "Error loading campaigns: ${t.message}", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    //Deleting a singular campaign by item long click
+    private fun deleteAdById(value:Int){
+        coroutineScope.launch {
+            val campaignid: Int = getIntent().extras?.getInt("campaignid") ?: -1
+            var deleteAdDeferred = AdServerApi.retrofitService.deleteAd(campaignid, value)
+            try {
+                var result = deleteAdDeferred.await()
+                Toast.makeText(applicationContext, "Success: ${result}", Toast.LENGTH_SHORT).show()
+            } catch (t: Throwable) {
+                Toast.makeText(applicationContext, "Error delete campaigns: ${t.message}", Toast.LENGTH_SHORT).show()
+            }
+            refreshAds()
+        }
     }
 }

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdServerApiService.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdServerApiService.kt
@@ -34,6 +34,18 @@ interface AdServerApiService {
     fun putCampaigns(@Path("campID") campID: Int, @Body item: CampaignPost):
             Deferred<String>
 
+    @DELETE("/campaigns/{campID}")
+    fun deleteCampaign(@Path("campID") campID: Int):
+            Deferred<String>
+
+    @GET("/campaigns/{campId}/ads")
+    fun getCampAds(@Path ("campId") campId: Int):
+            Deferred<List<Ads.AdItem>>
+
+    @DELETE("/campaigns/{campID}/ads/{adID}")
+    fun deleteAd(@Path("campId") campID: Int, @Path("adID") adID: Int):
+            Deferred<String>
+
     @DELETE("db")
     fun deleteCampaigns():
             Deferred<String>

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/Ads.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/Ads.kt
@@ -6,9 +6,9 @@ object Ads {
 
     var adList: MutableList<AdItem> = ArrayList()
 
-    init {
-        addItem(AdItem("Black Friday ads", "11/23/20", "www.google.com", "www.Google.com"))
-    }
+//    init {
+//        addItem(AdItem("Black Friday ads", "11/23/20", "www.google.com", "www.Google.com"))
+//    }
 
 
     fun addItem(item: AdItem) {
@@ -18,6 +18,10 @@ object Ads {
 
     fun clearItems(){
         adList.clear()
+    }
+
+    fun setItems(newItems: MutableList<AdItem>) {
+        adList = newItems
     }
 
     data class AdItem(

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MainActivity.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MainActivity.kt
@@ -40,17 +40,26 @@ class MainActivity : AppCompatActivity(), MyItemRecyclerViewAdapter.onCampaignCl
         }
     }
 
+    //coming back to home screen
     override fun onResume() {
         super.onResume()
         refreshCampaigns()
     }
 
+    //Selecting a campaign to see what ads exist in selected campaign
     override fun onItemClick(value: CampaignItem, position: Int) {
         val intent: Intent = Intent(this, AdFrag::class.java)
         intent.putExtra("campaignid", value.id)
         startActivity(intent)
     }
 
+    override fun onLongItemClick(value: CampaignItem, position: Int) {
+//        intent.putExtra("campaignid", value.id)
+//        startActivity(intent)
+        deleteCampaignById(value.id)
+    }
+
+    //Refreshing list after leaving home page and coming back to it
     private fun refreshCampaigns() {
         coroutineScope.launch {
             var getCampaignsDeferred = AdServerApi.retrofitService.getCampaigns()
@@ -65,9 +74,24 @@ class MainActivity : AppCompatActivity(), MyItemRecyclerViewAdapter.onCampaignCl
         }
     }
 
+    //Deleting all campaigns through "delete campaign" button click
     private fun deleteCampaigns(){
         coroutineScope.launch {
             var deleteCampaignsDeferred = AdServerApi.retrofitService.deleteCampaigns()
+            try {
+                var result = deleteCampaignsDeferred.await()
+                Toast.makeText(applicationContext, "Success: ${result}", Toast.LENGTH_SHORT).show()
+            } catch (t: Throwable) {
+                Toast.makeText(applicationContext, "Error delete campaigns: ${t.message}", Toast.LENGTH_SHORT).show()
+            }
+            refreshCampaigns()
+        }
+    }
+
+    //Deleting a singular campaign by item long click
+    private fun deleteCampaignById(value:Int){
+        coroutineScope.launch {
+            var deleteCampaignsDeferred = AdServerApi.retrofitService.deleteCampaign(value)
             try {
                 var result = deleteCampaignsDeferred.await()
                 Toast.makeText(applicationContext, "Success: ${result}", Toast.LENGTH_SHORT).show()

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MyAdRecyclerViewAdapter.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MyAdRecyclerViewAdapter.kt
@@ -45,10 +45,16 @@ class MyAdRecyclerViewAdapter(private var values: MutableList<Ads.AdItem>,
             itemView.setOnClickListener{
                 action.onItemClick(value, adapterPosition)
             }
+
+            itemView.setOnLongClickListener {
+                action.onLongItemClick(value, adapterPosition)
+                true
+            }
         }
     }
 
     interface onAdClickListener{
         fun onItemClick(value: Ads.AdItem, position: Int)
+        fun onLongItemClick(value: Ads.AdItem, position: Int)
     }
 }

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MyItemRecyclerViewAdapter.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MyItemRecyclerViewAdapter.kt
@@ -56,11 +56,17 @@ class MyItemRecyclerViewAdapter(
             itemView.setOnClickListener{
                 action.onItemClick(value, adapterPosition)
             }
+
+            itemView.setOnLongClickListener {
+                action.onLongItemClick(value, adapterPosition)
+                true
+            }
         }
     }
 
     interface onCampaignClickListener{
         fun onItemClick(value: CampaignItem, position: Int)
+        fun onLongItemClick(value: CampaignItem, position: Int)
     }
 
 }


### PR DESCRIPTION
Added onLongClick listener to both recycler view adapters to delete specific ads and campaigns. Delete specific campaign/ad doesn't work since backend hasn't finished implementing it. Added deleteAd/getcampAds/deleteCampaign to ServerApi, but getCampAds recieves error 'Missing URI template variable 'campId' from server.