### PR TITLE
Frontend: fix end of input

### DIFF
--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdFrag.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdFrag.kt
@@ -61,8 +61,7 @@ class AdFrag : AppCompatActivity(), MyAdRecyclerViewAdapter.onAdClickListener {
     }
 
     override fun onLongItemClick(value: AdItem, position: Int) {
-        val campaignid: Int = intent.extras?.getInt("campaignid") ?: -1
-        deleteAdById(campaignid)
+        deleteAdById(value.id)
     }
 
     //Refreshing list after leaving home page and coming back to it

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdFrag.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdFrag.kt
@@ -72,24 +72,33 @@ class AdFrag : AppCompatActivity(), MyAdRecyclerViewAdapter.onAdClickListener {
             try {
                 var listResult = getAdsDeferred.await()
                 Ads.setItems(listResult.toMutableList())
-                Toast.makeText(applicationContext, "Success: ${listResult.size}", Toast.LENGTH_SHORT).show()
+                Toast.makeText(
+                    applicationContext,
+                    "Success: ${listResult.size}",
+                    Toast.LENGTH_SHORT
+                ).show()
                 adAdapter.update(Ads.adList)
             } catch (t: Throwable) {
-                Toast.makeText(applicationContext, "Error loading campaigns: ${t.message}", Toast.LENGTH_SHORT).show()
+                Toast.makeText(
+                    applicationContext,
+                    "Error loading campaigns: ${t.message}",
+                    Toast.LENGTH_SHORT
+                ).show()
             }
         }
     }
 
-    //Deleting a singular campaign by item long click
-    private fun deleteAdById(value:Int){
+    //Deleting a singular ad by item long click
+    private fun deleteAdById(adid: Int) {
         coroutineScope.launch {
             val campaignid: Int = intent.extras?.getInt("campaignid") ?: -1
-            var deleteAdDeferred = AdServerApi.retrofitService.deleteAd(campaignid, value)
+            val deleteAdDeferred = AdServerApi.retrofitService.deleteAd(campaignid, adid)
             try {
-                var result = deleteAdDeferred.await()
-                Toast.makeText(applicationContext, "Success: ${result}", Toast.LENGTH_SHORT).show()
+                deleteAdDeferred.await()
+                Toast.makeText(applicationContext, "Success", Toast.LENGTH_SHORT).show()
             } catch (t: Throwable) {
-                Toast.makeText(applicationContext, "Error delete campaigns: ${t.message}", Toast.LENGTH_SHORT).show()
+                Toast.makeText(applicationContext, "Error deleting ad: $t", Toast.LENGTH_SHORT)
+                    .show()
             }
             refreshAds()
         }

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdServerApiService.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdServerApiService.kt
@@ -28,31 +28,31 @@ interface AdServerApiService {
 
     @POST("campaigns")
     fun postCampaigns(@Body item: CampaignPost):
-            Deferred<String>
+            Deferred<Unit>
 
     @PUT("campaigns/{campID}")
     fun putCampaigns(@Path("campID") campID: Int, @Body item: CampaignPost):
-            Deferred<String>
+            Deferred<Unit>
 
     @DELETE("/campaigns/{campID}")
     fun deleteCampaign(@Path("campID") campID: Int):
-            Deferred<String>
+            Deferred<Unit>
 
     @GET("/campaigns/{campID}/ads")
     fun getCampAds(@Path("campID") campID: Int):
             Deferred<List<AdItem>>
 
     @POST("/campaigns/{campID}/ads")
-    fun postCampAds(@Path("campID") campID: Int, @Body ad: AdItem):
-            Deferred<List<AdItem>>
+    fun postCampAds(@Path("campID") campID: Int, @Body ad: AdPost):
+            Deferred<Unit>
 
     @DELETE("/campaigns/{campID}/ads/{adID}")
     fun deleteAd(@Path("campID") campID: Int, @Path("adID") adID: Int):
-            Deferred<String>
+            Deferred<Unit>
 
     @DELETE("db")
     fun deleteCampaigns():
-            Deferred<String>
+            Deferred<Unit>
 }
 
 object AdServerApi {

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AddAdActivity.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AddAdActivity.kt
@@ -42,7 +42,7 @@ class AddAdActivity : AppCompatActivity() {
         val adUrl = adUrlTextView.text
         val adIP = adIPTextView.text
         val campaignid: Int = this.intent.extras?.getInt("campaignid") ?: -1
-        val newAd = AdItem(
+        val newAd = AdPost(
             adName.toString(),
             adSub.toString(),
             adUrl.toString(),

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AddAdActivity.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AddAdActivity.kt
@@ -52,8 +52,8 @@ class AddAdActivity : AppCompatActivity() {
         coroutineScope.launch {
             val postCampaignsDeferred = AdServerApi.retrofitService.postCampAds(campaignid, newAd)
             try {
-                val result = postCampaignsDeferred.await()
-                Toast.makeText(applicationContext, "Success: $result", Toast.LENGTH_SHORT).show()
+                postCampaignsDeferred.await()
+                Toast.makeText(applicationContext, "Success", Toast.LENGTH_SHORT).show()
             } catch (t: Throwable) {
                 Toast.makeText(
                     applicationContext,

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AddCampaignAcitivity.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AddCampaignAcitivity.kt
@@ -43,10 +43,10 @@ class AddCampaignActivity : AppCompatActivity() {
         )
 
         coroutineScope.launch {
-            var postCampaignsDeferred = AdServerApi.retrofitService.postCampaigns(campaign)
+            val postCampaignsDeferred = AdServerApi.retrofitService.postCampaigns(campaign)
             try {
-                var result = postCampaignsDeferred.await()
-                Toast.makeText(applicationContext, "Success: $result", Toast.LENGTH_SHORT).show()
+                postCampaignsDeferred.await()
+                Toast.makeText(applicationContext, "Success", Toast.LENGTH_SHORT).show()
             } catch (t: Throwable) {
                 Toast.makeText(
                     applicationContext,

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/Ads.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/Ads.kt
@@ -2,7 +2,16 @@ package com.example.adservermvp
 
 import java.util.ArrayList
 
+// Don't send an id when making a new ad.
+data class AdPost(
+    var mainText : String,
+    var subText: String,
+    var url: String,
+    var imagePath: String
+)
+
 data class AdItem(
+    var id: Int,
     var mainText : String,
     var subText: String,
     var url: String,
@@ -15,13 +24,7 @@ object Ads {
 
     var adList: MutableList<AdItem> = ArrayList()
 
-//    init {
-//        addItem(AdItem("Black Friday ads", "11/23/20", "www.google.com", "www.Google.com"))
-//    }
-
-
     fun addItem(item: AdItem) {
-//        ITEMS.addAll(item)
         adList.add(item)
     }
 

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MainActivity.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MainActivity.kt
@@ -54,8 +54,6 @@ class MainActivity : AppCompatActivity(), MyItemRecyclerViewAdapter.onCampaignCl
     }
 
     override fun onLongItemClick(value: CampaignItem, position: Int) {
-//        intent.putExtra("campaignid", value.id)
-//        startActivity(intent)
         deleteCampaignById(value.id)
     }
 

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MainActivity.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MainActivity.kt
@@ -60,9 +60,9 @@ class MainActivity : AppCompatActivity(), MyItemRecyclerViewAdapter.onCampaignCl
     //Refreshing list after leaving home page and coming back to it
     private fun refreshCampaigns() {
         coroutineScope.launch {
-            var getCampaignsDeferred = AdServerApi.retrofitService.getCampaigns()
+            val getCampaignsDeferred = AdServerApi.retrofitService.getCampaigns()
             try {
-                var listResult = getCampaignsDeferred.await()
+                val listResult = getCampaignsDeferred.await()
                 Campaign.setItems(listResult.toMutableList())
                 Toast.makeText(applicationContext, "Success: ${listResult.size}", Toast.LENGTH_SHORT).show()
                 campaignAdapter.update(Campaign.ITEMS)
@@ -75,10 +75,10 @@ class MainActivity : AppCompatActivity(), MyItemRecyclerViewAdapter.onCampaignCl
     //Deleting all campaigns through "delete campaign" button click
     private fun deleteCampaigns(){
         coroutineScope.launch {
-            var deleteCampaignsDeferred = AdServerApi.retrofitService.deleteCampaigns()
+            val deleteCampaignsDeferred = AdServerApi.retrofitService.deleteCampaigns()
             try {
-                var result = deleteCampaignsDeferred.await()
-                Toast.makeText(applicationContext, "Success: ${result}", Toast.LENGTH_SHORT).show()
+                deleteCampaignsDeferred.await()
+                Toast.makeText(applicationContext, "Success", Toast.LENGTH_SHORT).show()
             } catch (t: Throwable) {
                 Toast.makeText(applicationContext, "Error delete campaigns: ${t.message}", Toast.LENGTH_SHORT).show()
             }
@@ -92,7 +92,7 @@ class MainActivity : AppCompatActivity(), MyItemRecyclerViewAdapter.onCampaignCl
             var deleteCampaignsDeferred = AdServerApi.retrofitService.deleteCampaign(value)
             try {
                 var result = deleteCampaignsDeferred.await()
-                Toast.makeText(applicationContext, "Success: ${result}", Toast.LENGTH_SHORT).show()
+                Toast.makeText(applicationContext, "Success", Toast.LENGTH_SHORT).show()
             } catch (t: Throwable) {
                 Toast.makeText(applicationContext, "Error delete campaigns: ${t.message}", Toast.LENGTH_SHORT).show()
             }


### PR DESCRIPTION
We were trying to parse bodies from endpoints that return an empty body. 

This fixes that by making the endpoints return `Unit`.