### PR TITLE
Frontend: handle dates cleanly

### DIFF
--- a/frontend/AdServerMVP/app/build.gradle
+++ b/frontend/AdServerMVP/app/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.adservermvp"
-        minSdkVersion 16
+        minSdkVersion 24
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdFrag.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdFrag.kt
@@ -72,16 +72,11 @@ class AdFrag : AppCompatActivity(), MyAdRecyclerViewAdapter.onAdClickListener {
             try {
                 var listResult = getAdsDeferred.await()
                 Ads.setItems(listResult.toMutableList())
-                Toast.makeText(
-                    applicationContext,
-                    "Success: ${listResult.size}",
-                    Toast.LENGTH_SHORT
-                ).show()
                 adAdapter.update(Ads.adList)
             } catch (t: Throwable) {
                 Toast.makeText(
                     applicationContext,
-                    "Error loading campaigns: ${t.message}",
+                    "Error loading ads: ${t.message}",
                     Toast.LENGTH_SHORT
                 ).show()
             }

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdFrag.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AdFrag.kt
@@ -68,9 +68,9 @@ class AdFrag : AppCompatActivity(), MyAdRecyclerViewAdapter.onAdClickListener {
     private fun refreshAds() {
         coroutineScope.launch {
             val campaignid: Int = intent.extras?.getInt("campaignid") ?: -1
-            var getAdsDeferred = AdServerApi.retrofitService.getCampAds(campaignid)
+            val getAdsDeferred = AdServerApi.retrofitService.getCampAds(campaignid)
             try {
-                var listResult = getAdsDeferred.await()
+                val listResult = getAdsDeferred.await()
                 Ads.setItems(listResult.toMutableList())
                 adAdapter.update(Ads.adList)
             } catch (t: Throwable) {

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AddCampaignAcitivity.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/AddCampaignAcitivity.kt
@@ -1,5 +1,6 @@
 package com.example.adservermvp
 
+import android.app.DatePickerDialog
 import android.os.Bundle
 import android.widget.Button
 import android.widget.TextView
@@ -9,6 +10,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.*
 
 class AddCampaignActivity : AppCompatActivity() {
 
@@ -17,8 +20,15 @@ class AddCampaignActivity : AppCompatActivity() {
     lateinit var campaignStartDateTextView: TextView
     lateinit var campaignEndDateTextView: TextView
 
+    lateinit var pickStartDateButton: Button
+    lateinit var pickEndDateButton: Button
+
     private val campaignJob = Job()
     private val coroutineScope = CoroutineScope(campaignJob + Dispatchers.Main)
+
+    // Internal start and end date stored in epoch seconds
+    private var startDate: Long = 0
+    private var endDate: Long = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -29,17 +39,54 @@ class AddCampaignActivity : AppCompatActivity() {
         campaignStartDateTextView = findViewById<TextView>(R.id.textStartDate)
         campaignEndDateTextView = findViewById<TextView>(R.id.textEndDate)
 
+        val cal = Calendar.getInstance()
+        val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+
+        val startDateSetListener =
+            DatePickerDialog.OnDateSetListener { view, year, monthOfYear, dayOfMonth ->
+                cal.set(Calendar.YEAR, year)
+                cal.set(Calendar.MONTH, monthOfYear)
+                cal.set(Calendar.DAY_OF_MONTH, dayOfMonth)
+
+                startDate = cal.timeInMillis / 1000
+                campaignStartDateTextView.text = sdf.format(cal.time)
+            }
+
+        val endDateSetListener =
+            DatePickerDialog.OnDateSetListener { view, year, monthOfYear, dayOfMonth ->
+                cal.set(Calendar.YEAR, year)
+                cal.set(Calendar.MONTH, monthOfYear)
+                cal.set(Calendar.DAY_OF_MONTH, dayOfMonth)
+
+                endDate = cal.timeInMillis / 1000
+                campaignEndDateTextView.text = sdf.format(cal.time)
+            }
+
         submitButton.setOnClickListener { submitCampaign() }
+        campaignStartDateTextView.setOnClickListener {
+            DatePickerDialog(
+                this@AddCampaignActivity, startDateSetListener,
+                cal.get(Calendar.YEAR),
+                cal.get(Calendar.MONTH),
+                cal.get(Calendar.DAY_OF_MONTH)
+            ).show()
+        }
+        campaignEndDateTextView.setOnClickListener {
+            DatePickerDialog(
+                this@AddCampaignActivity, endDateSetListener,
+                cal.get(Calendar.YEAR),
+                cal.get(Calendar.MONTH),
+                cal.get(Calendar.DAY_OF_MONTH)
+            ).show()
+        }
     }
 
     private fun submitCampaign() {
         val campaignName = campaignNameTextView.text
-        val campaignStartDate = campaignStartDateTextView.text
-        val campaignEndDate = campaignEndDateTextView.text
         val campaign = CampaignPost(
             campaignName.toString(),
-            campaignStartDate.toString(),
-            campaignEndDate.toString()
+            startDate,
+            endDate
         )
 
         coroutineScope.launch {

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/Campaign.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/Campaign.kt
@@ -25,7 +25,8 @@ object Campaign {
      */
     var ITEMS: MutableList<CampaignItem> = ArrayList()
 
-    init {}
+    init {
+    }
 
     fun addItem(item: CampaignItem) {
         ITEMS.add(item)

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/Campaign.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/Campaign.kt
@@ -12,8 +12,8 @@ data class CampaignPost(
 data class CampaignItem(
     var id: Int,
     var name: String,
-    var startDate: String,
-    var endDate: String
+    var startDate: Long,
+    var endDate: Long
 ) {
     override fun toString(): String = name + startDate
 }

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/Campaign.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/Campaign.kt
@@ -5,8 +5,8 @@ import java.util.ArrayList
 // We don't send an id when creating a new campaign.
 data class CampaignPost(
     var name: String,
-    var startDate: String,
-    var endDate: String
+    var startDate: Long,
+    var endDate: Long
 )
 
 data class CampaignItem(

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/EditCampaignActivity.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/EditCampaignActivity.kt
@@ -1,5 +1,6 @@
 package com.example.adservermvp
 
+import android.app.DatePickerDialog
 import android.os.Bundle
 import android.widget.Button
 import android.widget.TextView
@@ -9,6 +10,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.*
 
 class EditCampaignActivity : AppCompatActivity() {
     lateinit var submitButton: Button
@@ -18,6 +21,10 @@ class EditCampaignActivity : AppCompatActivity() {
 
     private val campaignJob = Job()
     private val coroutineScope = CoroutineScope(campaignJob + Dispatchers.Main)
+
+    // Internal start and end date stored in epoch seconds, same as AddCampaignActivity
+    private var startDate: Long = 0
+    private var endDate: Long = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,17 +38,55 @@ class EditCampaignActivity : AppCompatActivity() {
         submitButton.setOnClickListener {
             handleSubmit()
         }
+
+        val cal = Calendar.getInstance()
+        val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+
+        val startDateSetListener =
+            DatePickerDialog.OnDateSetListener { view, year, monthOfYear, dayOfMonth ->
+                cal.set(Calendar.YEAR, year)
+                cal.set(Calendar.MONTH, monthOfYear)
+                cal.set(Calendar.DAY_OF_MONTH, dayOfMonth)
+
+                startDate = cal.timeInMillis / 1000
+                campaignStartDateTextView.text = sdf.format(cal.time)
+            }
+
+        val endDateSetListener =
+            DatePickerDialog.OnDateSetListener { view, year, monthOfYear, dayOfMonth ->
+                cal.set(Calendar.YEAR, year)
+                cal.set(Calendar.MONTH, monthOfYear)
+                cal.set(Calendar.DAY_OF_MONTH, dayOfMonth)
+
+                endDate = cal.timeInMillis / 1000
+                campaignEndDateTextView.text = sdf.format(cal.time)
+            }
+
+        campaignStartDateTextView.setOnClickListener {
+            DatePickerDialog(
+                this@EditCampaignActivity, startDateSetListener,
+                cal.get(Calendar.YEAR),
+                cal.get(Calendar.MONTH),
+                cal.get(Calendar.DAY_OF_MONTH)
+            ).show()
+        }
+        campaignEndDateTextView.setOnClickListener {
+            DatePickerDialog(
+                this@EditCampaignActivity, endDateSetListener,
+                cal.get(Calendar.YEAR),
+                cal.get(Calendar.MONTH),
+                cal.get(Calendar.DAY_OF_MONTH)
+            ).show()
+        }
     }
 
     private fun handleSubmit() {
         val campaignid: Int = getIntent().extras?.getInt("campaignid") ?: -1
         val campaignName = campaignNameTextView.text
-        val campaignStartDate = campaignStartDateTextView.text
-        val campaignEndDate = campaignEndDateTextView.text
         val campaign = CampaignPost(
             campaignName.toString(),
-            campaignStartDate.toString(),
-            campaignEndDate.toString()
+            startDate,
+            endDate
         )
 
         coroutineScope.launch {

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/EditCampaignActivity.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/EditCampaignActivity.kt
@@ -90,10 +90,10 @@ class EditCampaignActivity : AppCompatActivity() {
         )
 
         coroutineScope.launch {
-            var putCampaignsDeferred =
+            val putCampaignsDeferred =
                 AdServerApi.retrofitService.putCampaigns(campaignid, campaign)
             try {
-                var result = putCampaignsDeferred.await()
+                val result = putCampaignsDeferred.await()
                 Toast.makeText(applicationContext, "Success: $result", Toast.LENGTH_SHORT).show()
             } catch (t: Throwable) {
                 Toast.makeText(

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MainActivity.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MainActivity.kt
@@ -88,7 +88,7 @@ class MainActivity : AppCompatActivity(), MyItemRecyclerViewAdapter.onCampaignCl
     //Deleting a singular campaign by item long click
     private fun deleteCampaignById(value:Int){
         coroutineScope.launch {
-            var deleteCampaignsDeferred = AdServerApi.retrofitService.deleteCampaign(value)
+            val deleteCampaignsDeferred = AdServerApi.retrofitService.deleteCampaign(value)
             try {
                 deleteCampaignsDeferred.await()
                 Toast.makeText(applicationContext, "Success", Toast.LENGTH_SHORT).show()

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MainActivity.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MainActivity.kt
@@ -91,7 +91,7 @@ class MainActivity : AppCompatActivity(), MyItemRecyclerViewAdapter.onCampaignCl
         coroutineScope.launch {
             var deleteCampaignsDeferred = AdServerApi.retrofitService.deleteCampaign(value)
             try {
-                var result = deleteCampaignsDeferred.await()
+                deleteCampaignsDeferred.await()
                 Toast.makeText(applicationContext, "Success", Toast.LENGTH_SHORT).show()
             } catch (t: Throwable) {
                 Toast.makeText(applicationContext, "Error delete campaigns: ${t.message}", Toast.LENGTH_SHORT).show()

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MainActivity.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MainActivity.kt
@@ -64,7 +64,6 @@ class MainActivity : AppCompatActivity(), MyItemRecyclerViewAdapter.onCampaignCl
             try {
                 val listResult = getCampaignsDeferred.await()
                 Campaign.setItems(listResult.toMutableList())
-                Toast.makeText(applicationContext, "Success: ${listResult.size}", Toast.LENGTH_SHORT).show()
                 campaignAdapter.update(Campaign.ITEMS)
             } catch (t: Throwable) {
                 Toast.makeText(applicationContext, "Error loading campaigns: ${t.message}", Toast.LENGTH_SHORT).show()

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MyItemRecyclerViewAdapter.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MyItemRecyclerViewAdapter.kt
@@ -14,6 +14,8 @@ import androidx.core.content.ContextCompat.startActivity
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
+import java.text.SimpleDateFormat
+import java.util.*
 
 /**
  * [RecyclerView.Adapter] that can display a [CampaignItem].
@@ -48,10 +50,12 @@ class MyItemRecyclerViewAdapter(
         val dateView: TextView = view.findViewById(R.id.campaignStartDate)
         val endDateView: TextView = view.findViewById(R.id.campaignEndDate)
 
+        val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+
         fun initialize(value: CampaignItem, action:onCampaignClickListener){
             idView.text = value.name
-            dateView.text = value.startDate.toString()
-            endDateView.text = value.endDate.toString()
+            dateView.text = sdf.format(Date(value.startDate * 1000))
+            endDateView.text = sdf.format(Date(value.endDate * 1000))
 
             itemView.setOnClickListener{
                 action.onItemClick(value, adapterPosition)

--- a/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MyItemRecyclerViewAdapter.kt
+++ b/frontend/AdServerMVP/app/src/main/java/com/example/adservermvp/MyItemRecyclerViewAdapter.kt
@@ -50,8 +50,8 @@ class MyItemRecyclerViewAdapter(
 
         fun initialize(value: CampaignItem, action:onCampaignClickListener){
             idView.text = value.name
-            dateView.text = value.startDate
-            endDateView.text = value.endDate
+            dateView.text = value.startDate.toString()
+            endDateView.text = value.endDate.toString()
 
             itemView.setOnClickListener{
                 action.onItemClick(value, adapterPosition)

--- a/frontend/AdServerMVP/app/src/main/res/layout/add_campaign.xml
+++ b/frontend/AdServerMVP/app/src/main/res/layout/add_campaign.xml
@@ -1,27 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-
-    <EditText
-        android:id="@+id/textStartDate"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginTop="56dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginRight="16dp"
-        android:ems="10"
-        android:hint="Start Date"
-        android:inputType="date"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 
     <EditText
         android:id="@+id/editTextCampaign"
@@ -43,6 +24,37 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.007" />
 
+    <TextView
+        android:id="@+id/textStartDate"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="56dp"
+        android:layout_marginEnd="16dp"
+        android:ems="10"
+        android:text="Start Date"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toTopOf="@+id/textEndDate"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/textEndDate"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="108dp"
+        android:layout_marginEnd="16dp"
+        android:ems="10"
+        android:text="End Date"
+        android:textSize="18sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <Button
         android:id="@+id/submitButtonAd"
         android:layout_width="0dp"
@@ -56,20 +68,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <EditText
-        android:id="@+id/textEndDate"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginTop="100dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginRight="16dp"
-        android:ems="10"
-        android:hint="End Date"
-        android:inputType="date"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/AdServerMVP/app/src/main/res/layout/edit_campaign.xml
+++ b/frontend/AdServerMVP/app/src/main/res/layout/edit_campaign.xml
@@ -2,26 +2,8 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-
-    <EditText
-        android:id="@+id/textStartDate"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginTop="56dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginRight="16dp"
-        android:ems="10"
-        android:hint="Start Date"
-        android:inputType="date"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 
     <EditText
         android:id="@+id/editTextCampaign"
@@ -56,20 +38,35 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <EditText
+    <TextView
+        android:id="@+id/textStartDate"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="56dp"
+        android:layout_marginEnd="16dp"
+        android:ems="10"
+        android:text="Start Date"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toTopOf="@+id/textEndDate"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
         android:id="@+id/textEndDate"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginTop="100dp"
+        android:layout_marginTop="108dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginRight="16dp"
         android:ems="10"
-        android:hint="End Date"
-        android:inputType="date"
+        android:text="End Date"
+        android:textSize="18sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Use a DatePickerDialog to handle selecting the start and end date for campaigns, and format the dates nicely when showing them to the user.

Also gets rid of the "Success" toasts for GET calls.

Closes #61 